### PR TITLE
Fix OAS2 parameter conversion

### DIFF
--- a/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
+++ b/modules/swagger-parser-v2-converter/src/main/java/io/swagger/v3/parser/converter/SwaggerConverter.java
@@ -949,10 +949,18 @@ public class SwaggerConverter implements SwaggerParserExtension {
                     case "tsv":
                         break;
                     case "multi":
+                        if ("query".equals(v2Parameter.getIn())) {
+                            v3Parameter.setStyle(Parameter.StyleEnum.FORM);
+                            v3Parameter.setExplode(true);
+                        }
                         break;
                     case "csv":
                     default:
                         if ("query".equals(v2Parameter.getIn())) {
+                            v3Parameter.setStyle(Parameter.StyleEnum.FORM);
+                            v3Parameter.setExplode(false);
+                        } else if ("header".equals(v2Parameter.getIn()) || "path".equals(v2Parameter.getIn())) {
+                            v3Parameter.setStyle(Parameter.StyleEnum.SIMPLE);
                             v3Parameter.setExplode(false);
                         }
                 }

--- a/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
+++ b/modules/swagger-parser-v2-converter/src/test/java/io/swagger/parser/test/V2ConverterTest.java
@@ -29,14 +29,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class V2ConverterTest {
     private static final String PET_STORE_JSON = "petstore.json";
     private static final String PET_STORE_YAML = "petstore.yaml";
+    private static final String PARAMETER_CONVERSION_JSON = "parameter-conversion.json";
     private static final String ISSUE_2_JSON = "issue-2.json";
     private static final String ISSUE_3_JSON = "issue-3.json";
     private static final String ISSUE_4_JSON = "issue-4.json";
@@ -573,6 +571,29 @@ public class V2ConverterTest {
         assertNotNull(anEnum);
         assertEquals(anEnum.get(0), true);
         assertEquals(anEnum.get(1), false);
+    }
+
+    @Test(description = "OpenAPI v2 converter - Missing Parameter.style property")
+    public void testParameterConversion() throws Exception {
+        OpenAPI oas = getConvertedOpenAPIFromJsonFile(PARAMETER_CONVERSION_JSON);
+        List<Parameter> parameters = oas.getPaths().get(FOO_PATH).getGet().getParameters();
+        assertNotNull(parameters);
+
+        Parameter parameter = parameters.get(0);
+        assertEquals(parameter.getStyle(), Parameter.StyleEnum.FORM);
+        assertFalse(parameter.getExplode());
+
+        parameter = parameters.get(1);
+        assertEquals(parameter.getStyle(), Parameter.StyleEnum.FORM);
+        assertTrue(parameter.getExplode());
+
+        parameter = parameters.get(2);
+        assertEquals(parameter.getStyle(), Parameter.StyleEnum.SIMPLE);
+        assertFalse(parameter.getExplode());
+
+        parameter = parameters.get(3);
+        assertEquals(parameter.getStyle(), Parameter.StyleEnum.SIMPLE);
+        assertFalse(parameter.getExplode());
     }
 
     private OpenAPI getConvertedOpenAPIFromJsonFile(String file) throws IOException, URISyntaxException {

--- a/modules/swagger-parser-v2-converter/src/test/resources/parameter-conversion.json
+++ b/modules/swagger-parser-v2-converter/src/test/resources/parameter-conversion.json
@@ -1,0 +1,65 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "version": "1.0",
+        "title": "x-example"
+    },
+    "host": "httpbin.org",
+    "basePath": "/anything",
+    "schemes": [
+        "http"
+    ],
+    "paths": {
+        "/{foo}": {
+            "get": {
+                "parameters": [
+                    {
+                        "name": "query-csv",
+                        "in": "query",
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv"
+                    },
+                    {
+                        "name": "query-multi",
+                        "in": "query",
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi"
+                    },
+                    {
+                        "name": "header-csv",
+                        "in": "header",
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv"
+                    },
+                    {
+                        "name": "path-csv",
+                        "in": "path",
+                        "description": "",
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/swagger-api/swagger-parser/issues/690

This PR fixes OAS2 parameter conversion according to the summary below:

|OAS v2: in  |OAS v2: collectionFormat  |OAS v3: style  |OAS v3: explode|
|---|---|---|---|
|query  |csv  |form  |false|
|query  |multi  |form  |true|
|header  |csv  |simple  |false(default)|
|path  |csv  |simple  |false(default)|
|*  |ssv  |spaceDelimited  |false(default)|
|*  |pipes  |pipeDelimited  |false(default)|
|*  |tsv  |-  |-|