### PR TITLE
Test case demonstrating issue 834

### DIFF
--- a/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
+++ b/modules/swagger-parser-v3/src/test/java/io/swagger/v3/parser/test/OpenAPIV3ParserTest.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.ArraySchema;
 import io.swagger.v3.oas.models.media.ByteArraySchema;
 import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.Content;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.media.StringSchema;
@@ -55,6 +56,30 @@ import static org.testng.Assert.*;
 public class OpenAPIV3ParserTest {
     protected int serverPort = getDynamicPort();
     protected WireMockServer wireMockServer;
+
+    @Test
+    public void testIssue834() {
+        ParseOptions options = new ParseOptions();
+        options.setResolve(true);
+        SwaggerParseResult result = new OpenAPIV3Parser().readLocation("issue_834/index.yaml", null, options);
+        assertNotNull(result);
+        System.out.println(result.getOpenAPI());
+
+        Content foo200Content = result.getOpenAPI().getPaths().get("/foo").getGet().getResponses().get("200").getContent();
+        assertNotNull(foo200Content);
+        String foo200SchemaRef = foo200Content.get("application/json").getSchema().get$ref();
+        assertEquals(foo200SchemaRef, "#/components/schemas/schema");
+
+        Content foo300Content = result.getOpenAPI().getPaths().get("/foo").getGet().getResponses().get("300").getContent();
+        assertNotNull(foo300Content);
+        String foo300SchemaRef = foo300Content.get("application/json").getSchema().get$ref();
+        assertEquals(foo300SchemaRef, "#/components/schemas/schema");
+
+        Content bar200Content = result.getOpenAPI().getPaths().get("/bar").getGet().getResponses().get("200").getContent();
+        assertNotNull(bar200Content);
+        String bar200SchemaRef = bar200Content.get("application/json").getSchema().get$ref();
+        assertEquals(bar200SchemaRef, "#/components/schemas/schema");
+    }
 
     @Test
     public void testIssue811_RefSchema_ToRefSchema() {

--- a/modules/swagger-parser-v3/src/test/resources/issue_834/components/response1.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue_834/components/response1.yaml
@@ -1,0 +1,6 @@
+---
+description: Response with schema containing reference
+content:
+  application/json:
+    schema:
+      $ref: "./schema.yaml"

--- a/modules/swagger-parser-v3/src/test/resources/issue_834/components/response2.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue_834/components/response2.yaml
@@ -1,0 +1,6 @@
+---
+description: Response with schema containing reference
+content:
+  application/json:
+    schema:
+      $ref: "./schema.yaml"

--- a/modules/swagger-parser-v3/src/test/resources/issue_834/components/schema.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue_834/components/schema.yaml
@@ -1,0 +1,3 @@
+---
+type: object
+

--- a/modules/swagger-parser-v3/src/test/resources/issue_834/index.yaml
+++ b/modules/swagger-parser-v3/src/test/resources/issue_834/index.yaml
@@ -1,0 +1,32 @@
+---
+openapi: "3.0.0"
+externalDocs:
+  description: Test
+  url: http://test.com/test
+info:
+  version: 0.0.1
+  title: Test
+  license:
+    name: Test
+    url: http://test.com/test
+servers:
+  - url: http://test.com/test
+paths:
+  /foo:
+    get:
+      description: foo
+      summary: foo
+      operationId: foo
+      responses:
+        200:
+          $ref: "./components/response1.yaml"
+        300:
+          $ref: "./components/response2.yaml"
+  /bar:
+    get:
+      description: bar
+      summary: bar
+      operationId: bar
+      responses:
+        200:
+          $ref: "./components/response1.yaml"


### PR DESCRIPTION
Test case demonstrating issue with references to external schemas:

https://github.com/swagger-api/swagger-parser/issues/834

Expected behaviour:
`testIssue834` passes.

Actual behaviour:
`testIssue834` fails, with assertion `assertNotNull(bar200Content);` failing.