### PR TITLE
Fix ServiceLoader initializations

### DIFF
--- a/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
+++ b/modules/swagger-parser-v3/src/main/java/io/swagger/v3/parser/OpenAPIV3Parser.java
@@ -200,7 +200,7 @@ public class OpenAPIV3Parser implements SwaggerParserExtension {
     protected List<SwaggerParserExtension> getExtensions() {
         List<SwaggerParserExtension> extensions = new ArrayList<>();
 
-        ServiceLoader<SwaggerParserExtension> loader = ServiceLoader.load(SwaggerParserExtension.class);
+        ServiceLoader<SwaggerParserExtension> loader = ServiceLoader.load(SwaggerParserExtension.class, SwaggerParserExtension.class.getClassLoader());
         Iterator<SwaggerParserExtension> itr = loader.iterator();
         while (itr.hasNext()) {
             extensions.add(itr.next());

--- a/modules/swagger-parser/src/main/java/io/swagger/parser/OpenAPIParser.java
+++ b/modules/swagger-parser/src/main/java/io/swagger/parser/OpenAPIParser.java
@@ -41,7 +41,7 @@ public class OpenAPIParser {
     protected List<SwaggerParserExtension> getExtensions() {
         List<SwaggerParserExtension> extensions = new ArrayList<>();
 
-        ServiceLoader<SwaggerParserExtension> loader = ServiceLoader.load(SwaggerParserExtension.class);
+        ServiceLoader<SwaggerParserExtension> loader = ServiceLoader.load(SwaggerParserExtension.class, SwaggerParserExtension.class.getClassLoader());
         Iterator<SwaggerParserExtension> itr = loader.iterator();
         while (itr.hasNext()) {
             extensions.add(itr.next());


### PR DESCRIPTION
This PR fixes the service loader initializations for `SwaggerParserExtension` so that the correct class loader is used, regardless of the thread's context class loader.

This essentially fixes an issue that occurs when calling `OpenAPIParser.readLocation` (and subsequently `OpenAPIParser.getExtensions`) from a thread that doesn't use the same class loader which is used to load `swagger-parser` module (e.g. build tool plugins), and as a result, the parser is incapable of parsing OpenAPI 2.0 specs.

Related: https://github.com/OpenAPITools/openapi-generator/pull/2658